### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ Click the "Render" button top-right.
 
 You can edit the HTML that the test renders by editing the ./views/test1.html and ./views/test1.css files.
 
-#License
+# License
 This code is free to use, distribute, modify, copy, and whatever else you care to do with it. If you make a change that is beneficial, please consider forking this project and then submitting a pull request!
 
-#Isogenic Game Engine
+# Isogenic Game Engine
 This project is part of the Isogenic Game Engine, an HTML5 Networked, MMO, Isometric and 2D, Canvas or DOM, Realtime game engine for the modern web. http://www.isogenicengine.com.
 
 If you like this project, please +1 us on our site!


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
